### PR TITLE
Fix dependencies for langchain-deepseek and langchain-openai

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ passlib>=1.7.4
 python-multipart>=0.0.6
 langchain>=0.3.0
 langchain-community>=0.0.10
-langchain-openai>=0.0.5
+langchain-openai>=0.3.3
 langchain-chroma>=0.0.5
 chromadb>=0.6.3
 langchain-qdrant>=0.2.0
@@ -23,5 +23,5 @@ unstructured[md]>=0.10.0
 openai>=1.30.0
 email-validator
 dashscope>=1.13.6
-langchain-deepseek==0.1.1
+langchain-deepseek>=0.1.2
 langchain-ollama==0.2.3


### PR DESCRIPTION
Fixes #21

Update `backend/requirements.txt` to fix network error or server unreachable issue.

* Update `langchain-openai` to version `>=0.3.3`.
* Update `langchain-deepseek` to version `>=0.1.2`.

