### PR TITLE
CI: Add a GitHub action to check if the build process can pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+
+      - name: Run build
+        run: |
+          cd backend
+          python -m unittest discover
+
+      - name: Start backend server
+        run: |
+          cd backend
+          nohup python main.py &
+
+      - name: Wait for backend to start
+        run: sleep 5
+
+      - name: Perform end-to-end test
+        run: |
+          curl -f http://localhost:8000/api/v1/health

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,3 +25,4 @@ email-validator
 dashscope>=1.13.6
 langchain-deepseek==0.1.1
 langchain-ollama==0.2.3
+requests>=2.26.0


### PR DESCRIPTION
Related to #26

Add a GitHub action to check if the build process can pass and perform a simple end-to-end test.

* **Add `requests` package to dependencies**
  - Modify `backend/requirements.txt` to include `requests>=2.26.0`.

* **Create GitHub Actions workflow**
  - Add `.github/workflows/ci.yml` to define the CI workflow.
  - Trigger the workflow on push and pull request events to the `main` branch.
  - Include steps to set up the environment, install dependencies, run the build, start the backend server, wait for the server to start, and perform a cURL request to the API.

I am a green hand on the GitHub Action. If there any bugs or error, plz DM.
