### PR TITLE
update: Add default api_base and model in .env.example for deepseek.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,10 @@ OPENAI_MODEL=gpt-4
 OPENAI_EMBEDDINGS_MODEL=text-embedding-ada-002
 
 # Deepseek settings (required if CHAT_PROVIDER=deepseek)
-DEEPSEEK_API_KEY=
-DEEPSEEK_API_BASE=
-DEEPSEEK_MODEL=
+DEEPSEEK_API_KEY=your-deepseek-api-key-here
+DEEPSEEK_API_BASE=https://api.deepseek.com/v1
+# Deepseek model could be deepseek-chat or deepseek-reasoner
+DEEPSEEK_MODEL=deepseek-chat
 
 # Ollama settings (required if CHAT_PROVIDER=ollama, in docker compose, use host.docker.internal instead of localhost)
 


### PR DESCRIPTION
Add default `DEEPSEEK_API_BASE` and `DEEPSEEK_MODEL`  in .env.example file.